### PR TITLE
增加 asciibook workflow

### DIFF
--- a/.github/workflows/asciibook.yml
+++ b/.github/workflows/asciibook.yml
@@ -1,0 +1,17 @@
+name: Asciibook
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    container:
+      image: asciibook/asciibook:0.0.2-cjk-sc
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          asciibook build book.adoc --dest-dir build/asciibook
+      - uses: actions/upload-artifact@v1
+        with:
+          name: asciibook-build
+          path: build/asciibook


### PR DESCRIPTION
增加一个 asciibook 的 workflow，做了以下事情：

- 用 asciibook 构建图书，放到 build/asciibook 。
- 用 actions/upload-artifact 保存生成结果，然后可以在 workflow 的结果页面下载。

build/asciibook/html 里面的内容可以用于部署 gh-pages，有需要的话我可以提交这块脚本，不过先看看生成内容是否满意吧。

